### PR TITLE
Fix ssr.js

### DIFF
--- a/ssr.js
+++ b/ssr.js
@@ -75,7 +75,7 @@ const quillEditor = {
             var text = quill.getText()
             if (html === '<p><br></p>') {
               html = ''
-              quill.pasteHTML(html)
+              quill.root.innerHTML = html
             }
             if (model) {
               model.callback(html)
@@ -103,7 +103,11 @@ const quillEditor = {
           var oldData = el.children[0].innerHTML
           if (newData) {
             if (newData != oldData) {
-              quill.pasteHTML(newData)
+              const range = quill.getSelection();
+              quill.root.innerHTML = newData;
+              _.defer(() => {
+                quill.setSelection(range);
+              });
             }
           } else {
             quill.setText('')

--- a/ssr.js
+++ b/ssr.js
@@ -105,7 +105,7 @@ const quillEditor = {
             if (newData != oldData) {
               const range = quill.getSelection();
               quill.root.innerHTML = newData;
-              setTimeout(() => {
+              setTimeout(function() {
                 quill.setSelection(range);
               });
             }

--- a/ssr.js
+++ b/ssr.js
@@ -105,7 +105,7 @@ const quillEditor = {
             if (newData != oldData) {
               const range = quill.getSelection();
               quill.root.innerHTML = newData;
-              _.defer(() => {
+              setTimeout(() => {
                 quill.setSelection(range);
               });
             }


### PR DESCRIPTION
Quill.pasteHTML is deprecated.

And...

insert `<p>hello <strong>world</strong></p><p><br></p>` in content of property,

return `<p>hello <strong>world</strong></p>`


sorry, I cannot speak English.