### PR TITLE
Remove Quill from global context for security purposes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,12 @@
  * @author Surmon.me
  */
 
-window.Quill = require('quill/dist/quill.js')
+var quill = require('quill/dist/quill.js')
 var quillEditor = require('./src/editor.vue')
 quillEditor = quillEditor.default || quillEditor
 
 var VueQuillEditor = {
-  Quill: Quill,
+  Quill: quill,
   quillEditor: quillEditor,
   install: function(Vue) {
     Vue.component(quillEditor.name, quillEditor)


### PR DESCRIPTION
Removed Quill from window to prevent analyzers (like Wappalyzer) to detect that Quill is used.