### PR TITLE
Link to fix for Quill is defined error in modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Quill.register('modules/yourQuillModule', yourQuillModule)
 - [Option to insert an image from a URL](https://github.com/quilljs/quill/issues/893)
 - [How vue-quill-editor combine with the syntax highlighter module of highlight.js](https://github.com/surmon-china/vue-quill-editor/issues/39)
 - [配合 element-ui 实现上传图片/视频到七牛 demo](https://github.com/surmon-china/vue-quill-editor/issues/102)
+- [How to fix “Can’t find variable: Quill”, “Quill is undefined”, “window.Quill is undefined” errors when trying to use Quill modules that use Webpack in Nuxt/SSR](https://github.com/surmon-china/vue-quill-editor/issues/171#issuecomment-370253411)
 
 
 ## Quill documents


### PR DESCRIPTION
When trying to use a Quill module from Nuxt/SSR that itself uses Webpack, you must define Quill and window.Quill as Webpack plugins for the module to be able to find Quill. The linked to issue contains instructions and a fix. It also shows a different way to include Quill without SSR in a Nuxt app that allows use of the quill-editor component instead of a div.

Reference: #171 