### PR TITLE
Fix SSR receiving value update cause other inputs to lose focus

### DIFF
--- a/src/ssr.js
+++ b/src/ssr.js
@@ -136,7 +136,7 @@ const quillDirective = globalOptions => {
             const range = quill.getSelection()
             quill.root.innerHTML = newData
             setTimeout(() => {
-              quill.setSelection(range)
+              if (range) quill.setSelection(range)
             })
           }
         } else {


### PR DESCRIPTION
## Change
This PR will check if there is a range selected in quill and call it only when necessary.

## Expected behaviour
Updating value of the editor should not blur other input fields

## Current behaviour
When the SSR version of `vue-quill-editor` receive an updated value it will attempt to restore the `selection` within the text field.

```js
if (newData) {
  if (newData != oldData) {
    const range = quill.getSelection()
    quill.root.innerHTML = newData
    setTimeout(() => {
      quill.setSelection(range)
    })
  }
```
https://github.com/surmon-china/vue-quill-editor/blob/02c1741/src/ssr.js#L134-L141

However, `quill.setSelection(range)` is called even when `vue-quill-editor` is not focused. This usually cause the variable `range` to be `null`. Thus, `setSelection(null)` will cause quill to clear all selection instead. See: https://github.com/quilljs/quill/blob/16d4130a75d7bc2bfb7315694e69d1e08f764641/core/selection.js#L339

Example: https://codepen.io/amoshydra/pen/ZjYbRa
- Initially the example input field has focus and has text selected
- After`quill.setSelection(null)` is called the input field lose selection and lose focus

