### PR TITLE
replace the usage of pasteHTML() with setContents()

### DIFF
--- a/src/editor.vue
+++ b/src/editor.vue
@@ -125,7 +125,8 @@
         if (this.quill) {
           if (newVal && newVal !== this._content) {
             this._content = newVal
-            this.quill.pasteHTML(newVal)
+            const delta = this.quill.clipboard.convert(newVal)
+            this.quill.setContents(delta)
           } else if(!newVal) {
             this.quill.setText('')
           }
@@ -136,7 +137,8 @@
         if (this.quill) {
           if (newVal && newVal !== this._content) {
             this._content = newVal
-            this.quill.pasteHTML(newVal)
+            const delta = this.quill.clipboard.convert(newVal)
+            this.quill.setContents(delta)
           } else if(!newVal) {
             this.quill.setText('')
           }


### PR DESCRIPTION
pasteHTML() causes the browser to focus on the editor (since this imitates the user pasting text, the user would want to focus on the editor that they are pasting text inside of). If the editor is offscreen when this is done, the browser scrolls to the editor to focus it. 

Since the value of v-model is often changed when the page is first loaded, if there are multiple vue-quill-editors on the page, it can cause the page to become jittery (while the focus is jumping around on each of the v-model updates, because of the pasteHTML() call).