### PR TITLE
emit original quill event information with 'change'

### DIFF
--- a/examples/02-example.vue
+++ b/examples/02-example.vue
@@ -74,8 +74,8 @@
       }
     },
     methods: {
-      onEditorChange({ editor, html, text }) {
-        // console.log('editor change!', editor, html, text)
+      onEditorChange({ editor, html, text, quillEvent }) {
+        // console.log('editor change!', editor, html, text, quillEvent)
         this.content = html
       }
     },

--- a/examples/nuxt-ssr-example/nuxt-ssr-example.vue
+++ b/examples/nuxt-ssr-example/nuxt-ssr-example.vue
@@ -43,8 +43,8 @@
       onEditorReady(editor) {
         console.log('editor ready!', editor)
       },
-      onEditorChange({ editor, html, text }) {
-        console.log('editor change!', editor, html, text)
+      onEditorChange({ editor, html, text, quillEvent }) {
+        console.log('editor change!', editor, html, text, quillEvent)
         this.content = html
       }
     }

--- a/src/editor.vue
+++ b/src/editor.vue
@@ -104,14 +104,14 @@
           })
 
           // Update model if text changes
-          this.quill.on('text-change', (delta, oldDelta, source) => {
+          this.quill.on('text-change', (delta, oldContents, source) => {
             let html = this.$refs.editor.children[0].innerHTML
             const quill = this.quill
             const text = this.quill.getText()
             if (html === '<p><br></p>') html = ''
             this._content = html
             this.$emit('input', this._content)
-            this.$emit('change', { html, text, quill })
+            this.$emit('change', { html, text, quill, quillEvent: { delta, oldContents, source } })
           })
 
           // Emit ready event

--- a/src/ssr.js
+++ b/src/ssr.js
@@ -97,7 +97,7 @@ const quillDirective = globalOptions => {
         })
 
         // Update model if text changes
-        quill.on('text-change', (delta, oldDelta, source) => {
+        quill.on('text-change', (delta, oldContents, source) => {
           let html = el.children[0].innerHTML
           const text = quill.getText()
           if (html === '<p><br></p>') {
@@ -108,7 +108,7 @@ const quillDirective = globalOptions => {
             model.callback(html)
           }
           eventEmit(vnode, 'input', html)
-          eventEmit(vnode, 'change', { text, html, quill })
+          eventEmit(vnode, 'change', { text, html, quill, quillEvent: { delta, oldContents, source } })
         })
 
         // Emit ready event


### PR DESCRIPTION
With this PR i want to provide the original event parameters of the 'text-change'-event from quill to listeners of the 'change' event of the vue-quill-editor wrapper. 
I also changed the parameter naming from 'oldDelta' to 'oldContents' to match the current [quill event documentation](https://quilljs.com/docs/api/#events))

This change is 100% backward compatible. I also updated the examples in which a listener on 'change' is registered

Background info: In some cases i need to get the delta from a change and the source of the change. Currently i register an additional listener directly on quill but with this PR this would get much easier.  
